### PR TITLE
 move the header and Main Grid to userLayout #71

### DIFF
--- a/client/src/Components/Layout/Base/UserLayout.jsx
+++ b/client/src/Components/Layout/Base/UserLayout.jsx
@@ -1,18 +1,29 @@
 import React, { Component } from 'react';
 import Home from './../Home';
+import Header from './../../Common/Header/Header';
+import { Grid } from '@material-ui/core';
 export default class UserLayout extends Component {
   render() {
     return (
-      <div>
-        <Home
-          showlogo={true}
-          showMeun={true}
-          showAvatar={false}
-          isAvatarImage={false}
-          srcImage={null}
-          Name="User"
-        />
-      </div>
+      <Grid direction="column" container>
+        <Grid item xs={12}>
+          <Header
+            showlogo={true}
+            showMeun={true}
+            showAvatar={false}
+            isAvatarImage={false}
+            srcImage={null}
+            Name="User"
+          />
+        </Grid>
+        <Grid item container>
+          <Grid item xs={false} sm={3} />
+          <Grid item container xs={12} sm={6}>
+            <Home />
+          </Grid>
+          <Grid item xs={false} sm={3} />
+        </Grid>
+      </Grid>
     );
   }
 }

--- a/client/src/Components/Layout/Home.jsx
+++ b/client/src/Components/Layout/Home.jsx
@@ -5,45 +5,18 @@ import Header from '../Common/Header/Header';
 
 export default class Home extends Component {
   render() {
-    const {
-      showlogo,
-      showMeun,
-      showAvatar,
-      isAvatarImage,
-      srcImage,
-      Name,
-    } = this.props;
     return (
-      <Grid direction="column" container>
-        <Grid item xs={12}>
-          <Header
-            showlogo={showlogo}
-            showMeun={showMeun}
-            showAvatar={showAvatar}
-            isAvatarImage={isAvatarImage}
-            srcImage={srcImage}
-            Name={Name}
-          />
-        </Grid>
-        <Grid item container>
-          <Grid item xs={false} sm={3} />
-          <Grid item container xs={12} sm={6}>
-            <Box p={3}>
-              Lorem Ipsum is simply dummy text of the printing and typesetting
-              industry. Lorem Ipsum has been the industry's standard dummy text
-              ever since the 1500s, when an unknown printer took a galley of
-              type and scrambled it to make a type specimen book. It has
-              survived not only five centuries, but also the leap into
-              electronic typesetting, remaining essentially unchanged. It was
-              popularised in the 1960s with the release of Letraset sheets
-              containing Lorem Ipsum passages, and more recently with desktop
-              publishing software like Aldus PageMaker including versions of
-              Lorem Ipsum.
-            </Box>
-          </Grid>
-          <Grid item xs={false} sm={3} />
-        </Grid>
-      </Grid>
+      <Box p={3}>
+        Lorem Ipsum is simply dummy text of the printing and typesetting
+        industry. Lorem Ipsum has been the industry's standard dummy text ever
+        since the 1500s, when an unknown printer took a galley of type and
+        scrambled it to make a type specimen book. It has survived not only five
+        centuries, but also the leap into electronic typesetting, remaining
+        essentially unchanged. It was popularised in the 1960s with the release
+        of Letraset sheets containing Lorem Ipsum passages, and more recently
+        with desktop publishing software like Aldus PageMaker including versions
+        of Lorem Ipsum.
+      </Box>
     );
   }
 }


### PR DESCRIPTION
move the header and Main Grid to userLayout to loose coupling between components and Base Layout and to manage the main Grid of All pages from single point